### PR TITLE
Adds lastActivity monitoring for edge-cases when timer is stopped/resumed

### DIFF
--- a/projects/angular-user-idle/src/lib/angular-user-idle.service.ts
+++ b/projects/angular-user-idle/src/lib/angular-user-idle.service.ts
@@ -109,7 +109,6 @@ export class UserIdleService {
         filter(arr => arr.length && !this.isIdleDetected && !this.isInactivityTimer)
     ).subscribe(() => {
       this.lastActivity = UserIdleService.nowInSeconds();
-      console.debug(`${new Date()} last activity recorded`);
     });
 
     if (this.idleSubscription) {


### PR DESCRIPTION
Purpose of this PR is to address issue with computer in sleep mode. When computer is in sleep timers are stopped - idle calculates incorrectly (if we're talking about absolute values).

I added lastActivity UNIX-time in seconds and compare this lastActivity with current time during timeout timer.

I know it looks not as nice as the library-code itself, I'm ready to clean it up according to maintainer's requirements.