### PR TITLE
version increased to 2.2.5

### DIFF
--- a/projects/angular-user-idle/package.json
+++ b/projects/angular-user-idle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-user-idle",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "User's idle service for Angular 6+",
   "repository": {
     "type": "git",


### PR DESCRIPTION
there were some issues regarding the angular update to 10 and then to 11

like I mentioned here: https://github.com/rednez/angular-user-idle/issues/96#issuecomment-717834132

you see that people still having problems sometimes https://github.com/rednez/angular-user-idle/issues/98

it seemed like your changes are not being present in the final npm package in the npm registry
or our local registries are caching it still?

Would it make sense to just increase the version and deploy it? 