### PR TITLE
Improve install process for angular 7-11

### DIFF
--- a/projects/angular-user-idle/package.json
+++ b/projects/angular-user-idle/package.json
@@ -9,8 +9,8 @@
   "author": "Vasyl Efimenko <rednez@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/common": "^6.0.0 || ^12.0.0",
-    "@angular/core": "^6.0.0 || ^12.0.0",
+    "@angular/common": ">=6.0.0",
+    "@angular/core": ">=6.0.0",
     "rxjs": "^6.0.0"
   }
 }


### PR DESCRIPTION
This modifies the `peerDependencies` so Angular 7-11 do not throw errors running `npm install`. This is especially important as npm 7 is stricter than prior npm versions and requires users to retry the command with `--force`, or `--legacy-peer-deps` as shown in this install example on an empty project:

```bash
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: demo-peer-deps-issue@1.0.0
npm ERR! Found: @angular/common@10.2.5
npm ERR! node_modules/@angular/common
npm ERR!   @angular/common@"10.2.5" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer @angular/common@"^6.0.0 || ^12.0.0" from angular-user-idle@2.2.7
npm ERR! node_modules/angular-user-idle
npm ERR!   angular-user-idle@"2.2.7" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/user/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/user/.npm/_logs/2021-09-14T23_43_26_809Z-debug.log
```

I followed the `>=VERSION` convention from `jest-preset-angular`'s [`package.json`](https://github.com/thymikee/jest-preset-angular/blob/main/package.json#L49). 

Resolves #120 

BTW: This library is awesome @rednez ⭐