### PR TITLE
bump peer dependencies for angular 14

### DIFF
--- a/projects/angular-user-idle/package.json
+++ b/projects/angular-user-idle/package.json
@@ -9,8 +9,8 @@
   "author": "Vasyl Efimenko <rednez@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/common": "^6.0.0 || ^12.0.0",
-    "@angular/core": "^6.0.0 || ^12.0.0",
+    "@angular/common": ">6.0.0 && <14.0.0",
+    "@angular/core": ">6.0.0 && <14.0.0",
     "rxjs": "^6.0.0"
   }
 }


### PR DESCRIPTION
I check support for angular 14 and it seems to work fine with angular 14, so I just bumped that. any issues with it please let me know and I can fix it